### PR TITLE
Skip arrays while merging context

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/frctl/nunjucks",
   "dependencies": {
-    "@frctl/fractal": "^1.0.0-rc.1",
+    "@frctl/fractal": "^1.1.0",
     "bluebird": "^3.3.4",
     "lodash": "^4.0.0",
     "nunjucks": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "url": "https://github.com/frctl/nunjucks/issues"
   },
   "homepage": "https://github.com/frctl/nunjucks",
+  "peerDependencies": {
+    "@frctl/fractal": ">= 1.1.0-alpha.0 < 2"
+  },
   "dependencies": {
-    "@frctl/fractal": "^1.1.0",
     "bluebird": "^3.3.4",
     "lodash": "^4.0.0",
     "nunjucks": "^2.4.2"

--- a/src/extensions/render.js
+++ b/src/extensions/render.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const utils = require('@frctl/fractal').utils;
 
 module.exports = function(fractal){
 
@@ -33,7 +33,7 @@ module.exports = function(fractal){
             if (!context) {
                 context = defaultContext;
             } else if (merge) {
-                context = _.defaultsDeep(context, defaultContext);
+                context = utils.defaultsDeep(context, defaultContext);
             }
 
             source.resolve(context).then(context => {


### PR DESCRIPTION
In an attempt to fix https://github.com/frctl/fractal/issues/123#issuecomment-241975017, I propose to use Fractal own defaultsDeep method to avoid merging the content of arrays while merging contexts.

I had to bump the minimal Fractal version since this method is available only since version 1.1.0.