### PR TITLE
Improve environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ If you want to register custom [filters](https://mozilla.github.io/nunjucks/api.
 ```javascript
 
 const nunj = require('@frctl/nunjucks')({
+    env: {
+      // Nunjucks environment opts: https://mozilla.github.io/nunjucks/api.html#configure
+    },
     filters: {
         // filter-name: function filterFunc(){}
     },

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -87,9 +87,7 @@ class NunjucksAdapter extends Adapter {
          * Instantiate the Nunjucks environment instance.
          */
 
-        let nj = Promise.promisifyAll(new nunjucks.Environment(loaders, {
-            autoescape: false
-        }));
+        let nj = Promise.promisifyAll(new nunjucks.Environment(loaders));
 
         this._engine = nj;
     }

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -9,7 +9,7 @@ const Adapter  = require('@frctl/fractal').Adapter;
 
 class NunjucksAdapter extends Adapter {
 
-    constructor(source, loadPaths, app) {
+    constructor(source, config, app) {
 
         super(null, source);
 
@@ -46,7 +46,7 @@ class NunjucksAdapter extends Adapter {
          *  include a FileSystemLoader instance.
          */
 
-        if (loadPaths) {
+        if (config.paths) {
 
             const FileSystemLoader = nunjucks.Loader.extend({
 
@@ -80,14 +80,14 @@ class NunjucksAdapter extends Adapter {
                     };
                  }
             });
-            loaders.push(new FileSystemLoader(loadPaths));
+            loaders.push(new FileSystemLoader(config.paths));
         }
 
         /**
          * Instantiate the Nunjucks environment instance.
          */
 
-        let nj = Promise.promisifyAll(new nunjucks.Environment(loaders));
+        let nj = Promise.promisifyAll(new nunjucks.Environment(loaders, config.env || {}));
 
         this._engine = nj;
     }
@@ -117,7 +117,7 @@ module.exports = function(config) {
 
         register(source, app) {
 
-            const adapter = new NunjucksAdapter(source, config.paths, app);
+            const adapter = new NunjucksAdapter(source, config, app);
             const nj = adapter.engine;
 
             if (!config.pristine) {


### PR DESCRIPTION
This PR switches `autoescape` to be enabled by default (as per the standard Nunjucks default behaviour) and adds the ability to pass options to the Nunjucks environment via the configuration object.

This is a breaking change so is intended be released as part of the v2.0 release of this adapter.