### PR TITLE
Update nunjucks to be ^3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "bluebird": "^3.3.4",
     "lodash": "^4.0.0",
-    "nunjucks": "^2.4.2"
+    "nunjucks": "^3.1.3"
   }
 }


### PR DESCRIPTION
This brings inline with [frctl/fractal](https://github.com/frctl/fractal/blob/develop/package.json#L45) and brings useful features from Nunjucks 3.x to files processed by the adapter (like `{{ variable | dump(2) }}`