### PR TITLE
Fetch request context for README.md

### DIFF
--- a/src/filters/path.js
+++ b/src/filters/path.js
@@ -8,7 +8,7 @@ module.exports = function(fractal) {
     return function(path) {
 
         let env = this.lookup('_env');
-        let request = env.request || this.lookup('_request');
+        let request = env.request || this.lookup('_request') || this.ctx.request;
 
         return (! env || env.server) ? path : utils.relUrlPath(path, _.get(request, 'path', '/'), fractal.web.get('builder.urls'));
     }


### PR DESCRIPTION
When using the njk extension for README.md notes, the request isn't available.

That means doing something like: `{{ '/assets/vf-figure/assets/figure-example.png' | path}}` fails as the `path` filter doesn't know what URL the request is coming from. 

---

Verbose info:

Doing `{{ '/assets/vf-figure/assets/figure-example.png' | path}}` in a README.md gives:

- Currently: `assets/vf-figure/assets/figure-example.png`
- With PR: `../../assets/vf-figure/assets/figure-example.png`